### PR TITLE
docs: add complaint 7 to COMPLAINS.md

### DIFF
--- a/COMPLAINS.md
+++ b/COMPLAINS.md
@@ -87,3 +87,14 @@ Implement "Restore" / "Unarchive" functionality immediately.
 - **Tab Details:** Add a "Restore to Open Tabs" button for archived items.
 - **Bulk Actions:** Allow selecting multiple archived tabs and clicking "Restore".
 - **Logic:** Move the record back to the `open_tabs` table (or update its status) and remove it from the `archived_tabs` view.
+
+## 7. The Amnesiac Filters (Device Filter Illusion)
+
+**The Problem:**
+The device filtering dropdown in the UI only populates its list of available devices based on the *currently visible page* of tabs. It completely forgets about devices that exist on other pages of data.
+
+**Why this matters:**
+This renders the filtering system functionally broken. If I want to filter my view to only see tabs from my "Work Laptop", but none of the most recent 20 tabs are from that device, "Work Laptop" won't even appear in the filter dropdown! I cannot filter for what the UI refuses to acknowledge exists. It creates a confusing, fluctuating list of devices that changes every time I change pages, completely defeating the purpose of a global filter.
+
+**The Demand:**
+Fix this immediately. Decouple device discovery from pagination. Fetch a distinct, global list of `device_names` from the backend dataset upon application load, regardless of which page of tabs the user is currently viewing. Stop gaslighting users about which devices they have synced.


### PR DESCRIPTION
Added Complaint #7 to `COMPLAINS.md`. This complains about the device filtering dropdown, which only populates based on the current page of tabs, instead of from a distinct global list of devices.

---
*PR created automatically by Jules for task [18083952903992949649](https://jules.google.com/task/18083952903992949649) started by @nhanquach*