### PR TITLE
docs: add complaint about incomplete device filtering

### DIFF
--- a/COMPLAINS.md
+++ b/COMPLAINS.md
@@ -87,3 +87,14 @@ Implement "Restore" / "Unarchive" functionality immediately.
 - **Tab Details:** Add a "Restore to Open Tabs" button for archived items.
 - **Bulk Actions:** Allow selecting multiple archived tabs and clicking "Restore".
 - **Logic:** Move the record back to the `open_tabs` table (or update its status) and remove it from the `archived_tabs` view.
+
+## 7. The Amnesiac Filters (Incomplete Device Filtering)
+
+**The Problem:**
+The device list used for filtering the tabs in the main interface is populated exclusively from the *currently loaded page* of tabs. If I have a device that only has tabs saved on "Page 3" of my paginated view, that device will completely vanish from the filter dropdown until I manually paginate to that page.
+
+**Why this matters:**
+This renders the filtering system fundamentally useless as a discovery or navigation tool. A filter should allow me to narrow down a global dataset. Instead, the application's filter can only narrow down the 20 items I am already looking at. It forces the user to memorize which devices have tabs on which page, completely defeating the purpose of a cross-device syncing application. It is a structural failure disguised as a minor UI bug.
+
+**The Demand:**
+Decouple device discovery from pagination. The device dropdown must always display the full, distinct list of all devices associated with my account, regardless of which page of tabs I am currently viewing. The frontend needs to fetch this distinct list from the backend global dataset, not derive it dynamically from local state.


### PR DESCRIPTION
Added a new user complaint to `COMPLAINS.md` about the "Amnesiac Filters" issue.

- **The Problem**: The device filter list is dynamically generated only from the currently visible page of tabs, causing devices on other pages to vanish from the filter options.
- **Why this matters**: This makes cross-device filtering fundamentally useless as a discovery tool since it cannot filter the global dataset, forcing users to manually paginate.
- **The Demand**: Decouple device discovery from pagination and fetch the complete, distinct list of devices directly from the backend to ensure a persistent and accurate filter dropdown.

This fulfills the user request to add a unique, valuable complaint while adopting a demanding, hard-to-please persona and maintaining the existing document formatting.

---
*PR created automatically by Jules for task [16751043147198990975](https://jules.google.com/task/16751043147198990975) started by @nhanquach*