### PR TITLE
docs(complaints): add complaint #7 regarding visual previews

### DIFF
--- a/COMPLAINS.md
+++ b/COMPLAINS.md
@@ -87,3 +87,17 @@ Implement "Restore" / "Unarchive" functionality immediately.
 - **Tab Details:** Add a "Restore to Open Tabs" button for archived items.
 - **Bulk Actions:** Allow selecting multiple archived tabs and clicking "Restore".
 - **Logic:** Move the record back to the `open_tabs` table (or update its status) and remove it from the `archived_tabs` view.
+
+## 7. The Blind Tab Grid (No Visual Previews)
+
+**The Problem:**
+The application's tab list does not currently display visual previews, thumbnails, or favicons, rendering saved tabs strictly as text (Titles and URLs).
+
+**Why this matters:**
+This forces users to rely entirely on reading text to identify tabs, which is slow and cognitively demanding. Visual cues are crucial for quickly locating a specific tab among dozens. A "visual bookmark" manager without visuals is an oxymoron. It feels like using a terminal interface instead of a modern web application.
+
+**The Demand:**
+Implement visual previews immediately.
+- **Thumbnails:** Fetch and display Open Graph images or webpage screenshots for each tab.
+- **Favicons:** At a minimum, display the favicon of the website next to the title.
+- **Toggle:** Provide a view toggle between "List" (compact) and "Grid" (visual) to satisfy different user preferences.


### PR DESCRIPTION
This PR adds Complaint #7 to `COMPLAINS.md`, outlining the lack of visual previews for saved tabs in the application.

*   Added a new section `# 7. The Blind Tab Grid (No Visual Previews)` detailing the problem.
*   Included "Why this matters" explaining the cognitive load of text-only lists.
*   Added "The Demand" suggesting implementation of thumbnails, favicons, and a List/Grid toggle view.

---
*PR created automatically by Jules for task [15580055459692085666](https://jules.google.com/task/15580055459692085666) started by @nhanquach*