### PR TITLE
docs(complaints): add complaint #7 regarding missing offline mode

### DIFF
--- a/COMPLAINS.md
+++ b/COMPLAINS.md
@@ -87,3 +87,17 @@ Implement "Restore" / "Unarchive" functionality immediately.
 - **Tab Details:** Add a "Restore to Open Tabs" button for archived items.
 - **Bulk Actions:** Allow selecting multiple archived tabs and clicking "Restore".
 - **Logic:** Move the record back to the `open_tabs` table (or update its status) and remove it from the `archived_tabs` view.
+
+## 7. The Fragile Tether (No Offline Mode)
+
+**The Problem:**
+The application functions strictly as a thin terminal dependent on a continuous, active Supabase connection. It completely lacks offline capabilities and local data caching.
+
+**Why this matters:**
+This architectural choice creates a fragile user experience. If my internet connection drops for even a minute, or if I'm working from a cafe with spotty Wi-Fi, the application becomes an unusable brick. It cannot even display the tabs I had loaded seconds ago. A productivity tool must be reliable, and a hard dependency on an external server for basic read operations guarantees that it will fail precisely when I need it most.
+
+**The Demand:**
+Implement offline capabilities immediately.
+- **Caching:** Cache loaded tabs locally using IndexedDB or `localStorage` so they remain visible when offline.
+- **Offline Actions:** Queue actions (like archiving or deleting tabs) locally while offline, and sync them back to the server automatically when the connection is restored.
+- Stop treating my device as a dumb terminal.


### PR DESCRIPTION
Added a new complaint about the lack of offline capabilities to `COMPLAINS.md`. This fulfills the user's request to add a unique, valuable complaint written from the perspective of a demanding user.

The complaint points out the fragility of relying completely on an active connection for basic read operations (viewing loaded tabs) and demands local caching (`IndexedDB` / `localStorage`) as well as an offline action queue for operations like archiving or deleting tabs.

Changes made:
- Used a bash heredoc to append the complaint text to `COMPLAINS.md`.
- Numbered the complaint `# 7` sequentially based on the existing file content.
- Verified file integrity using `grep` and `tail`.
- Reverted unrelated `yarn.lock` modifications introduced by `yarn install` during verification.

---
*PR created automatically by Jules for task [8572142685608610722](https://jules.google.com/task/8572142685608610722) started by @nhanquach*